### PR TITLE
Wrong reference of MaskableMethods's instance

### DIFF
--- a/typescript/factories/other-main.ts
+++ b/typescript/factories/other-main.ts
@@ -15,5 +15,5 @@ class MaskableMethods {
 const demoMaskableMethods = new MaskableMethods();
 
 for (const key of ["foo", "bar"]) {
-    console.log(key, demo[key]);
+    console.log(key, demoMaskableMethods[key]);
 }


### PR DESCRIPTION
demo[key] will throw a ReferenceError.